### PR TITLE
'npm install gzip' fails with node@v0.3.0-pre

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   , "web" : "http://github.com/donnerjack13589/node.gzip/issues"
   }
 , "directories" : { "lib" : "./lib/gzio" }
-, "engines" : { "node" : ">=0.2" }
+, "engines" : { "node" : ">=v0.2.0" }
 , "licenses" :
   [ { "type" : "MIT"
     , "url" : "http://github.com/donnerjack13589/node.gzip/raw/master/LICENSE"


### PR DESCRIPTION
Good news everyone!

If I do 

```
$> npm install gzip
```

I get this error:

```
npm info it worked if it ends with ok
npm info using npm@0.2.3-3
npm ERR! Error: gzip@0.0.2 not compatible with your version of node
npm ERR! Requires: node@>=v0.2
npm ERR! You have: node@v0.3.0-pre
npm ERR!     at ../npm/0.2.3-3/package/lib/install.js:173:32
npm ERR!     at ../npm/0.2.3-3/package/lib/cache.js:185:11
npm ERR!     at cb (../npm/0.2.3-3/package/lib/utils/graceful-fs.js:28:9)
npm ERR!     at node.js:603:9
npm ERR! npm install <tarball file>
npm ERR! npm install <tarball url>
npm ERR! npm install <folder>
npm ERR! npm install <pkg>
npm ERR! npm install <pkg>@<tag>
npm ERR! npm install <pkg>@<version>
npm ERR! npm install <pkg>@<version range>
npm ERR! 
npm ERR! Can specify one or more: npm install ./foo.tgz bar@stable /some/folder
npm ERR! Installs '.' if no argument supplied
npm ERR! try running: 'npm help install'
npm ERR! Report this *entire* log at <http://github.com/isaacs/npm/issues>
npm ERR! or email it to <npm-@googlegroups.com>
npm not ok
```

Attached is a fix that probably better mirrors your intent (also, works fine afterwards):

```
npm install donnerjack13589-node.gzip-b44aa86/
npm info it worked if it ends with ok
npm info using npm@0.2.3-3
npm info install gzip@0.0.2
npm info activate gzip@0.0.2
npm info build Success: gzip@0.0.2
npm ok
```

Also: Could you publish a (fixed) version 0.0.3 to the registry ? All there is is 0.0.1 (not sure about the differences).

Have a nice day!
