### PR TITLE
Fix npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bugs" :
   {
     "mail" : "fedor.indutny@gmail.com",
-    "web" : "http://github.com/donnerjack13589/node.gzip/issues"
+    "url" : "http://github.com/donnerjack13589/node.gzip/issues"
   },
   "directories" : { "lib" : "./lib/gzip" },
   "main": "lib/gzip/index",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name" : "gzip",
   "description" : "Gzip for node",
   "version" : "0.1.0",
-  "homepage" : "http://github.com/donnerjack13589/node.gzip",
-  "author" : "Fedor Indutny <fedor.indutny@gmail.com> (http://github.com/donnerjack13589)",
+  "homepage" : "http://github.com/indutny/node.gzip",
+  "author" : "Fedor Indutny <fedor.indutny@gmail.com> (http://github.com/indutny)",
   "repository" : { 
     "type" : "git",
-    "url" : "http://github.com/donnerjack13589/node.gzip.git"
+    "url" : "http://github.com/indutny/node.gzip.git"
   },
   "bugs" :
   {
     "mail" : "fedor.indutny@gmail.com",
-    "url" : "http://github.com/donnerjack13589/node.gzip/issues"
+    "url" : "http://github.com/indutny/node.gzip/issues"
   },
   "directories" : { "lib" : "./lib/gzip" },
   "main": "lib/gzip/index",
@@ -19,7 +19,7 @@
   "licenses" :
   [ {
       "type" : "MIT",
-      "url" : "http://github.com/donnerjack13589/node.gzip/raw/master/LICENSE"
+      "url" : "http://github.com/indutny/node.gzip/raw/master/LICENSE"
     }
   ]
 }


### PR DESCRIPTION
In new versions of NPM using `bugs.web` in the `package.json` file causes a npm warning during installation.

I changed this to `bugs.url`.

I also fixed the URLs to your Github profile and the repo, since I believe you renamed it.
